### PR TITLE
remove the quick action caveat

### DIFF
--- a/README
+++ b/README
@@ -50,15 +50,6 @@ CAVEATS
     a CFs Validation to (?#Mandatory). will not magically make it enforced
     by this extension.
 
-  Actions menu
-    This extension does not affect "quick actions" (those without an update
-    type) configured in your lifecycle (and appearing in the ticket Actions
-    menu). If you're requiring fields on resolve, for example, and don't
-    want folks to have a "Quick Resolve" button that skips the required
-    fields, adjust your lifecycle config to provide an update type (i.e make
-    it a non-quick action). Quick actions may be supported in a future
-    release.
-
   Not all pages where you can change status are supported
     SelfService, for example. See "TODO" for others.
 

--- a/lib/RT/Extension/MandatoryOnTransition.pm
+++ b/lib/RT/Extension/MandatoryOnTransition.pm
@@ -67,15 +67,6 @@ rules.  If you've set Validation patterns for your custom fields, those will be
 checked before mandatory-ness is checked.  B<< Setting a CFs Validation to
 C<(?#Mandatory).> will not magically make it enforced by this extension. >>
 
-=head2 Actions menu
-
-This extension does B<not> affect "quick actions" (those without an update
-type) configured in your lifecycle (and appearing in the ticket Actions menu).
-If you're requiring fields on resolve, for example, and don't want folks to
-have a "Quick Resolve" button that skips the required fields, adjust your
-lifecycle config to provide an update type (i.e make it a non-quick action).
-Quick actions may be supported in a future release.
-
 =head2 Not all pages where you can change status are supported
 
 SelfService, for example.  See L</TODO> for others.


### PR DESCRIPTION
Quick actions are routed through Ticket/Update.html and bd147bd added
support for this page, so the caveat doesn't apply anymore.
